### PR TITLE
Allow matching a filename with a pattern

### DIFF
--- a/rpaths.py
+++ b/rpaths.py
@@ -996,8 +996,12 @@ class Pattern(object):
     def _prepare_path(path):
         # Here we want to force the use of replacement characters.
         # The __unicode__ implementation might use 'surrogateescape'
+        replace = False
         if isinstance(path, AbstractPath):
+            replace = path._lib.sep if path._lib.sep != '/' else None
             path = path.path
+        else:
+            replace = Path._lib.sep if Path._lib.sep != '/' else None
         if isinstance(path, bytes):
             path = path.decode(sys.getfilesystemencoding(), 'replace')
         elif not isinstance(path, unicode):
@@ -1005,6 +1009,9 @@ class Pattern(object):
 
         if path.startswith('/'):
             path = path[1:]
+
+        if replace is not None:
+            path = path.replace(replace, '/')
 
         return path
 

--- a/rpaths.py
+++ b/rpaths.py
@@ -1034,7 +1034,7 @@ def pattern2re(pattern):
         return '', re.compile(''), None
     elif '/' in pattern:
         full_regex = '^'  # Start at beginning of path
-        int_regex = ['^']
+        int_regex = []
         int_regex_done = False
         start_dir = []
         start_dir_done = False

--- a/tests/test_concrete.py
+++ b/tests/test_concrete.py
@@ -163,17 +163,23 @@ class TestLists(unittest.TestCase):
 class TestPattern2Re(unittest.TestCase):
     """Tests the pattern2re() function, used to recognize extended patterns.
     """
-    def do_test_pattern(self, pattern, start, tests):
+    def do_test_pattern(self, pattern, start, tests, interm=False):
         s, fr, ir = pattern2re(pattern)
         error = ''
         if s != start:
             error += "\n%r didn't start at %r (but %r)" % (pattern, start, s)
+        if interm:
+            r = ir
+            suffix = " (interm=True)"
+        else:
+            r = fr
+            suffix = ""
         for path, expected in tests:
-            passed = fr.search(path)
+            passed = r.search(path)
             if passed and not expected:
-                error += "\n%r matched %r" % (pattern, path)
+                error += "\n%r matched %r%s" % (pattern, path, suffix)
             elif not passed and expected:
-                error += "\n%r didn't match %r" % (pattern, path)
+                error += "\n%r didn't match %r%s" % (pattern, path, suffix)
         if error:
             self.fail(error)
 
@@ -280,6 +286,16 @@ class TestPattern2Re(unittest.TestCase):
              ('some:]file', True),
              ('someb]file', False),
              ('somebfile', False)])
+
+    def test_iterm(self):
+        """Tests the int_regex return value."""
+        self.do_test_pattern(
+            r'/usr/path/*.txt',
+            'usr/path',
+            [('usr', True),
+             ('usr/path', True),
+             ('usr/lib', False)],
+            interm=True)
 
 
 class TestDictUnion(unittest.TestCase):


### PR DESCRIPTION
Currently patterns are only accepted in listdir() and recursedir(). There should be a way to match a single file with a pattern.